### PR TITLE
ci: auto-fix lint and prettier issues in pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 permissions:
-    contents: read
+    contents: write
 
 on:
     pull_request:
@@ -14,6 +14,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
+              with:
+                  ref: ${{ github.head_ref }}
 
             - uses: pnpm/action-setup@v5
               with:
@@ -28,10 +30,15 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Lint
-              run: pnpm run lint
+              run: pnpm run lint:fix
 
-            - name: Format check
-              run: pnpm run format:check
+            - name: Format
+              run: pnpm run format
+
+            - name: Commit lint & formatting fixes
+              uses: stefanzweifel/git-auto-commit-action@v7
+              with:
+                  commit_message: 'style: apply lint and prettier fixes'
 
             - name: Type check
               run: pnpm run type-check


### PR DESCRIPTION
Replace format:check and lint with their auto-fix equivalents so that CI automatically corrects style issues on any PR, including Dependabot.

- Elevate contents permission to write so CI can push back to the branch
- Add ref: github.head_ref to checkout so commits target the PR branch
- Replace \lint\ with \lint:fix\ (eslint --fix)
- Replace \ormat:check\ with \ormat\ (prettier --write)
- Add stefanzweifel/git-auto-commit-action@v7 to commit any fixes; the action is a no-op when no files were changed, preventing CI loops